### PR TITLE
simple version check for module manager

### DIFF
--- a/Earmouse/src/pk/contender/earmouse/Main.java
+++ b/Earmouse/src/pk/contender/earmouse/Main.java
@@ -13,6 +13,7 @@ import android.content.res.Resources;
 import android.media.AudioManager;
 import android.os.Bundle;
 import android.os.StrictMode;
+import android.support.annotation.Nullable;
 import android.text.Html;
 import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
@@ -386,6 +387,21 @@ public class Main extends Activity implements ModuleListFragment.OnModuleSelecte
      */
     static public List<Module> getModuleList() {
         return mModules;
+    }
+
+    /**
+     * Returns the module with given id or null if not found
+     * @param id
+     * @return found module or null
+     */
+    @Nullable
+    static public Module getModuleById(int id) {
+        for(Module mod : mModules) {
+            if (mod.getId() == id) {
+                return mod;
+            }
+        }
+        return null;
     }
 
     /**

--- a/Earmouse/src/pk/contender/earmouse/ModuleManagerActivity.java
+++ b/Earmouse/src/pk/contender/earmouse/ModuleManagerActivity.java
@@ -362,15 +362,17 @@ public class ModuleManagerActivity extends Activity implements ManagerListFragme
 
             List<Integer> idsToRemove = new ArrayList<>();
 
-            for(Module mod : Main.getModuleList())
-                idsToRemove.add(mod.getId());
             for(Module mod : shownModuleList)
                 idsToRemove.add(mod.getId());
-            // idsToRemove now contains all the Module IDS that are either are already installed or
-            // already shown in the list so need not be added.
-            for(Module mod : result)
-                if(!idsToRemove.contains(mod.getId()))
-                    shownModuleList.add(mod);
+            // idsToRemove now contains all the Module IDS that are already shown in the list so need not be added.
+            Module modLocal;
+            for(Module mod : result) {
+                if (!idsToRemove.contains(mod.getId())) {
+                    if ((modLocal = Main.getModuleById(mod.getId())) == null || modLocal.getModuleVersion() < mod.getModuleVersion()) {
+                        shownModuleList.add(mod);
+                    }
+                }
+            }
 
             Collections.sort(shownModuleList);
 


### PR DESCRIPTION
Modules from the json list that have higher `module_version` will be presented for installation.

There is no further check of the version, so if the list lies, the module will still be installed.

I'm not sure why the current list (whatever this is), is not cleaned by a successful download, so maybe there are modules with older versions that are not tested.  But because there are already displayed they can be installed and the version check is not necessary.